### PR TITLE
Added sdmoduledir make file variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,6 +100,8 @@ if test "$ax_cv_boost_thread" != "yes"
 then AC_MSG_ERROR([Boost thread support library is missing or corrupted])
 fi
 
+SD_MODULE_DIR([${libdir}/speech-dispatcher-modules])
+
 # Check for additional headers.
 AC_CHECK_HEADERS([libspeechd_version.h])
 

--- a/m4/sd_module.m4
+++ b/m4/sd_module.m4
@@ -1,0 +1,18 @@
+# Configure paths for libsndfile
+#
+# Designed especially for the Multispeech project
+# by Artem Semenov <savoptik@altlinux.org>
+#
+#	Adds the following arguments to configure:
+# --with-sdmodule-dir=DIR
+#
+
+AC_DEFUN([SD_MODULE_DIR],
+[
+    AC_ARG_WITH([sdmodule-dir],
+        [AS_HELP_STRING([--with-sdmodule-dir=DIR], [directory for Speech Dispatcher modules @<:@default: $1@:>@])],
+        [sdmodule_dir="$withval"],
+        [sdmodule_dir="$1"]
+    )
+    AC_SUBST([sdmodule_dir])
+])

--- a/src/ssip/Makefile.am
+++ b/src/ssip/Makefile.am
@@ -1,6 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
-sdmoduledir = $(bindir)
+sdmoduledir = @sdmodule_dir@
 sdmodule_PROGRAMS = sd_multispeech
 
 AM_CPPFLAGS = -DSYSCONF_DIR=\"$(sysconfdir)\" -DDATA_DIR=\"$(datadir)\" \

--- a/src/ssip/Makefile.am
+++ b/src/ssip/Makefile.am
@@ -1,6 +1,7 @@
 ## Process this file with automake to produce Makefile.in
 
-bin_PROGRAMS = sd_multispeech
+sdmoduledir = $(bindir)
+sdmodule_PROGRAMS = sd_multispeech
 
 AM_CPPFLAGS = -DSYSCONF_DIR=\"$(sysconfdir)\" -DDATA_DIR=\"$(datadir)\" \
 	-I$(top_srcdir)/src/core @BOOST_CPPFLAGS@ @BOBCAT_CPPFLAGS@ @PORTAUDIOCPP_CPPFLAGS@


### PR DESCRIPTION
I suggest adding a variable to the make file to specify the installation path of the speech dispatcher module.